### PR TITLE
Add ISO 15118-20 schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ workspace.yaml
 /modules/target
 CMakeLists.txt.user
 .idea/
+venv/

--- a/tools/schemas/iso20/V2G_CI_AC.xsd
+++ b/tools/schemas/iso20/V2G_CI_AC.xsd
@@ -1,0 +1,250 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:iso:std:iso:15118:-20:AC" xmlns:v2gci_ct="urn:iso:std:iso:15118:-20:CommonTypes" targetNamespace="urn:iso:std:iso:15118:-20:AC" elementFormDefault="qualified" attributeFormDefault="qualified" version="15118:-20">
+	<xs:import namespace="urn:iso:std:iso:15118:-20:CommonTypes" schemaLocation="V2G_CI_CommonTypes.xsd"/>
+	<!--             -->
+	<!-- ––––––––––– -->
+	<!-- AC Messages -->
+	<!-- ––––––––––– -->
+	<!--                               -->
+	<!-- AC Charge Parameter Discovery -->
+	<!--                               -->
+	<xs:element name="AC_ChargeParameterDiscoveryReq" type="AC_ChargeParameterDiscoveryReqType"/>
+	<xs:complexType name="AC_ChargeParameterDiscoveryReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeParameterDiscoveryReqType">
+				<xs:sequence>
+					<xs:element ref="AC_CPDReqEnergyTransferMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="AC_ChargeParameterDiscoveryRes" type="AC_ChargeParameterDiscoveryResType"/>
+	<xs:complexType name="AC_ChargeParameterDiscoveryResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeParameterDiscoveryResType">
+				<xs:sequence>
+					<xs:element ref="AC_CPDResEnergyTransferMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                -->
+	<!-- AC Charge Loop -->
+	<!--                -->
+	<xs:element name="AC_ChargeLoopReq" type="AC_ChargeLoopReqType"/>
+	<xs:complexType name="AC_ChargeLoopReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeLoopReqType">
+				<xs:sequence>
+					<xs:element ref="v2gci_ct:CLReqControlMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="AC_ChargeLoopRes" type="AC_ChargeLoopResType"/>
+	<xs:complexType name="AC_ChargeLoopResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeLoopResType">
+				<xs:sequence>
+					<xs:element name="EVSETargetFrequency" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element ref="v2gci_ct:CLResControlMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                        -->
+	<!-- –––––––––––––––––––––– -->
+	<!-- Message Specific Types -->
+	<!-- –––––––––––––––––––––– -->
+	<!--                               -->
+	<!-- AC Charge Parameter Discovery -->
+	<!--                               -->
+	<!-- Energy Transfer Mode - AC -->
+	<xs:element name="AC_CPDReqEnergyTransferMode" type="AC_CPDReqEnergyTransferModeType"/>
+	<xs:complexType name="AC_CPDReqEnergyTransferModeType">
+		<xs:sequence>
+			<xs:element name="EVMaximumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMaximumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVMaximumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVMinimumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMinimumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVMinimumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="AC_CPDResEnergyTransferMode" type="AC_CPDResEnergyTransferModeType"/>
+	<xs:complexType name="AC_CPDResEnergyTransferModeType">
+		<xs:sequence>
+			<xs:element name="EVSEMaximumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEMaximumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSEMaximumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSEMinimumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEMinimumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSEMinimumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSENominalFrequency" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="MaximumPowerAsymmetry" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSEPowerRampLimitation" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSEPresentActivePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSEPresentActivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVSEPresentActivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- Energy Transfer Mode - AC BPT -->
+	<xs:element name="BPT_AC_CPDReqEnergyTransferMode" type="BPT_AC_CPDReqEnergyTransferModeType" substitutionGroup="AC_CPDReqEnergyTransferMode"/>
+	<xs:complexType name="BPT_AC_CPDReqEnergyTransferModeType">
+		<xs:complexContent>
+			<xs:extension base="AC_CPDReqEnergyTransferModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="BPT_AC_CPDResEnergyTransferMode" type="BPT_AC_CPDResEnergyTransferModeType" substitutionGroup="AC_CPDResEnergyTransferMode"/>
+	<xs:complexType name="BPT_AC_CPDResEnergyTransferModeType">
+		<xs:complexContent>
+			<xs:extension base="AC_CPDResEnergyTransferModeType">
+				<xs:sequence>
+					<xs:element name="EVSEMaximumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMaximumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMaximumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMinimumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMinimumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMinimumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                -->
+	<!-- AC Charge Loop -->
+	<!--                -->
+	<!-- Control Modes - Scheduled -->
+	<xs:element name="Scheduled_AC_CLReqControlMode" type="Scheduled_AC_CLReqControlModeType" substitutionGroup="v2gci_ct:CLReqControlMode"/>
+	<xs:complexType name="Scheduled_AC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Scheduled_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumChargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumChargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentActivePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVPresentActivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentActivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentReactivePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentReactivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentReactivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="Scheduled_AC_CLResControlMode" type="Scheduled_AC_CLResControlModeType" substitutionGroup="v2gci_ct:CLResControlMode"/>
+	<xs:complexType name="Scheduled_AC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Scheduled_CLResControlModeType">
+				<xs:sequence>
+					<xs:element name="EVSETargetActivePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetActivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetActivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetReactivePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetReactivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetReactivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEPresentActivePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEPresentActivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEPresentActivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- Control Modes - Scheduled - BPT -->
+	<xs:element name="BPT_Scheduled_AC_CLReqControlMode" type="BPT_Scheduled_AC_CLReqControlModeType" substitutionGroup="Scheduled_AC_CLReqControlMode"/>
+	<xs:complexType name="BPT_Scheduled_AC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Scheduled_AC_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumDischargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="BPT_Scheduled_AC_CLResControlMode" type="BPT_Scheduled_AC_CLResControlModeType" substitutionGroup="Scheduled_AC_CLResControlMode"/>
+	<xs:complexType name="BPT_Scheduled_AC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Scheduled_AC_CLResControlModeType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- Control Modes - Dynamic -->
+	<xs:element name="Dynamic_AC_CLReqControlMode" type="Dynamic_AC_CLReqControlModeType" substitutionGroup="v2gci_ct:CLReqControlMode"/>
+	<xs:complexType name="Dynamic_AC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Dynamic_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumChargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumChargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumChargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumChargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentActivePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVPresentActivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentActivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentReactivePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVPresentReactivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPresentReactivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="Dynamic_AC_CLResControlMode" type="Dynamic_AC_CLResControlModeType" substitutionGroup="v2gci_ct:CLResControlMode"/>
+	<xs:complexType name="Dynamic_AC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Dynamic_CLResControlModeType">
+				<xs:sequence>
+					<xs:element name="EVSETargetActivePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSETargetActivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetActivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetReactivePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetReactivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSETargetReactivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEPresentActivePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEPresentActivePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEPresentActivePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- Control Modes - Dynamic - BPT -->
+	<xs:element name="BPT_Dynamic_AC_CLReqControlMode" type="BPT_Dynamic_AC_CLReqControlModeType" substitutionGroup="Dynamic_AC_CLReqControlMode"/>
+	<xs:complexType name="BPT_Dynamic_AC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Dynamic_AC_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumDischargePower_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumV2XEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumV2XEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="BPT_Dynamic_AC_CLResControlMode" type="BPT_Dynamic_AC_CLResControlModeType" substitutionGroup="Dynamic_AC_CLResControlMode"/>
+	<xs:complexType name="BPT_Dynamic_AC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Dynamic_AC_CLResControlModeType"/>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>

--- a/tools/schemas/iso20/V2G_CI_ACDP.xsd
+++ b/tools/schemas/iso20/V2G_CI_ACDP.xsd
@@ -1,0 +1,174 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:iso:std:iso:15118:-20:ACDP" xmlns:v2gci_ct="urn:iso:std:iso:15118:-20:CommonTypes" targetNamespace="urn:iso:std:iso:15118:-20:ACDP" elementFormDefault="qualified" attributeFormDefault="qualified" version="15118:-20">
+	<xs:import namespace="urn:iso:std:iso:15118:-20:CommonTypes" schemaLocation="V2G_CI_CommonTypes.xsd"/>
+	<!--               -->
+	<!-- ––––––––––––– -->
+	<!-- ACDP Messages -->
+	<!-- ––––––––––––– -->
+	<!--                          -->
+	<!-- ACDP Vehicle Positioning -->
+	<!--                          -->
+	<xs:element name="ACDP_VehiclePositioningReq" type="ACDP_VehiclePositioningReqType"/>
+	<xs:complexType name="ACDP_VehiclePositioningReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVMobilityStatus" type="xs:boolean"/>
+					<xs:element name="EVPositioningSupport" type="xs:boolean"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="ACDP_VehiclePositioningRes" type="ACDP_VehiclePositioningResType"/>
+	<xs:complexType name="ACDP_VehiclePositioningResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="EVSEPositioningSupport" type="xs:boolean"/>
+					<xs:element name="EVRelativeXDeviation" type="xs:short"/>
+					<xs:element name="EVRelativeYDeviation" type="xs:short"/>
+					<xs:element name="ContactWindowXc" type="xs:short"/>
+					<xs:element name="ContactWindowYc" type="xs:short"/>
+					<xs:element name="EVInChargePosition" type="xs:boolean"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--              -->
+	<!-- ACDP Connect -->
+	<!--              -->
+	<xs:element name="ACDP_ConnectReq" type="ACDP_ConnectReqType"/>
+	<xs:complexType name="ACDP_ConnectReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVElectricalChargingDeviceStatus" type="electricalChargingDeviceStatusType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="ACDP_ConnectRes" type="ACDP_ConnectResType"/>
+	<xs:complexType name="ACDP_ConnectResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="EVSEElectricalChargingDeviceStatus" type="electricalChargingDeviceStatusType"/>
+					<xs:element name="EVSEMechanicalChargingDeviceStatus" type="mechanicalChargingDeviceStatusType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                 -->
+	<!-- ACDP Disconnect -->
+	<!--                 -->
+	<xs:element name="ACDP_DisconnectReq" type="ACDP_ConnectReqType"/>
+	<!--
+	<xs:complexType name="ACDP_DisconnectReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	-->
+	<xs:element name="ACDP_DisconnectRes" type="ACDP_ConnectResType"/>
+	<!--
+	<xs:complexType name="ACDP_DisconnectResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	-->
+	<!--                    -->
+	<!-- ACDP System Status -->
+	<!--                    -->
+	<xs:element name="ACDP_SystemStatusReq" type="ACDP_SystemStatusReqType"/>
+	<xs:complexType name="ACDP_SystemStatusReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVTechnicalStatus" type="EVTechnicalStatusType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="ACDP_SystemStatusRes" type="ACDP_SystemStatusResType"/>
+	<xs:complexType name="ACDP_SystemStatusResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEMechanicalChargingDeviceStatus" type="mechanicalChargingDeviceStatusType"/>
+					<xs:element name="EVSEReadyToCharge" type="xs:boolean"/>
+					<xs:element name="EVSEIsolationStatus" type="isolationStatusType"/>
+					<xs:element name="EVSEDisabled" type="xs:boolean"/>
+					<xs:element name="EVSEUtilityInterruptEvent" type="xs:boolean"/>
+					<xs:element name="EVSEEmergencyShutdown" type="xs:boolean"/>
+					<xs:element name="EVSEMalfunction" type="xs:boolean"/>
+					<xs:element name="EVInChargePosition" type="xs:boolean"/>
+					<xs:element name="EVAssociationStatus" type="xs:boolean"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                        -->
+	<!-- –––––––––––––––––––––– -->
+	<!-- Message Specific Types -->
+	<!-- –––––––––––––––––––––– -->
+	<xs:simpleType name="cpStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="StateA"/>
+			<xs:enumeration value="StateB"/>
+			<xs:enumeration value="StateC"/>
+			<xs:enumeration value="StateD"/>
+			<xs:enumeration value="StateE"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="errorCodeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="OK_NoEVError"/>
+			<xs:enumeration value="FAILED"/>
+			<xs:enumeration value="FAILED_EmergencyEvent"/>
+			<xs:enumeration value="FAILED_Breaker"/>
+			<xs:enumeration value="FAILED_RESSTemperatureInhibit"/>
+			<xs:enumeration value="FAILED_RESS"/>
+			<xs:enumeration value="FAILED_ChargingCurrentDifferential"/>
+			<xs:enumeration value="FAILED_ChargingVoltageOutOfRange"/>
+			<xs:enumeration value="FAILED_Reserved1"/>
+			<xs:enumeration value="FAILED_Reserved2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="isolationStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Invalid"/>
+			<xs:enumeration value="Safe"/>
+			<xs:enumeration value="Warning"/>
+			<xs:enumeration value="Fault"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="electricalChargingDeviceStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="State_A"/>
+			<xs:enumeration value="State_B"/>
+			<xs:enumeration value="State_C"/>
+			<xs:enumeration value="State_D"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="mechanicalChargingDeviceStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Home"/>
+			<xs:enumeration value="Moving"/>
+			<xs:enumeration value="EndPosition"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="EVTechnicalStatusType">
+		<xs:sequence>
+			<xs:element name="EVReadyToCharge" type="xs:boolean"/>
+			<xs:element name="EVImmobilizationRequest" type="xs:boolean"/>
+			<xs:element name="EVImmobilized" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="EVWLANStrength" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVCPStatus" type="cpStatusType" minOccurs="0"/>
+			<xs:element name="EVSOC" type="v2gci_ct:percentValueType" minOccurs="0"/>
+			<xs:element name="EVErrorCode" type="errorCodeType" minOccurs="0"/>
+			<xs:element name="EVTimeout" type="xs:boolean" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/tools/schemas/iso20/V2G_CI_AppProtocol.xsd
+++ b/tools/schemas/iso20/V2G_CI_AppProtocol.xsd
@@ -1,0 +1,55 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	xmlns="urn:iso:15118:2:2010:AppProtocol" 
+	targetNamespace="urn:iso:15118:2:2010:AppProtocol">
+	
+	<xs:element name="supportedAppProtocolReq">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="AppProtocol" type="AppProtocolType" maxOccurs="20"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="supportedAppProtocolRes">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="ResponseCode" type="responseCodeType"/>
+				<xs:element name="SchemaID" type="idType" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="AppProtocolType">
+		<xs:sequence>
+			<xs:element name="ProtocolNamespace" type="protocolNamespaceType"/>
+			<xs:element name="VersionNumberMajor" type="xs:unsignedInt"/>
+			<xs:element name="VersionNumberMinor" type="xs:unsignedInt"/>
+			<xs:element name="SchemaID" type="idType"/>
+			<xs:element name="Priority" type="priorityType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="idType">
+		<xs:restriction base="xs:unsignedByte"/>
+	</xs:simpleType>
+	<xs:simpleType name="protocolNameType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="30"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="protocolNamespaceType">
+		<xs:restriction base="xs:anyURI">
+			<xs:maxLength value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="priorityType">
+		<xs:restriction base="xs:unsignedByte">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="responseCodeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="OK_SuccessfulNegotiation"/>
+			<xs:enumeration value="OK_SuccessfulNegotiationWithMinorDeviation"/>
+			<xs:enumeration value="Failed_NoNegotiation"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/tools/schemas/iso20/V2G_CI_CommonMessages.xsd
+++ b/tools/schemas/iso20/V2G_CI_CommonMessages.xsd
@@ -1,0 +1,911 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:iso:std:iso:15118:-20:CommonMessages" xmlns:v2gci_ct="urn:iso:std:iso:15118:-20:CommonTypes" targetNamespace="urn:iso:std:iso:15118:-20:CommonMessages" elementFormDefault="qualified" attributeFormDefault="qualified" version="15118:-20">
+	<xs:import namespace="urn:iso:std:iso:15118:-20:CommonTypes" schemaLocation="V2G_CI_CommonTypes.xsd"/>
+	<!-- ––––––––––––––– -->
+	<!-- Common Messages -->
+	<!-- ––––––––––––––– -->
+	<!--               -->
+	<!-- Session Setup -->
+	<!--               -->
+	<xs:element name="SessionSetupReq" type="SessionSetupReqType"/>
+	<xs:complexType name="SessionSetupReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVCCID" type="v2gci_ct:identifierType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="SessionSetupRes" type="SessionSetupResType"/>
+	<xs:complexType name="SessionSetupResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEID" type="v2gci_ct:identifierType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                     -->
+	<!-- Authorization Setup -->
+	<!--                     -->
+	<xs:element name="AuthorizationSetupReq" type="AuthorizationSetupReqType"/>
+	<xs:complexType name="AuthorizationSetupReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="AuthorizationSetupRes" type="AuthorizationSetupResType"/>
+	<xs:complexType name="AuthorizationSetupResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="AuthorizationServices" type="authorizationType" maxOccurs="2"/>
+					<xs:element name="CertificateInstallationService" type="xs:boolean"/>
+					<xs:choice>
+						<xs:element name="EIM_ASResAuthorizationMode" type="EIM_ASResAuthorizationModeType"/>
+						<xs:element name="PnC_ASResAuthorizationMode" type="PnC_ASResAuthorizationModeType"/>
+					</xs:choice>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--               -->
+	<!-- Authorization -->
+	<!--               -->
+	<xs:element name="AuthorizationReq" type="AuthorizationReqType"/>
+	<xs:complexType name="AuthorizationReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="SelectedAuthorizationService" type="authorizationType"/>
+					<xs:choice>
+						<xs:element name="EIM_AReqAuthorizationMode" type="EIM_AReqAuthorizationModeType"/>
+						<xs:element name="PnC_AReqAuthorizationMode" type="PnC_AReqAuthorizationModeType"/>
+					</xs:choice>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="AuthorizationRes" type="AuthorizationResType"/>
+	<xs:complexType name="AuthorizationResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                   -->
+	<!-- Service Discovery -->
+	<!--                   -->
+	<xs:element name="ServiceDiscoveryReq" type="ServiceDiscoveryReqType"/>
+	<xs:complexType name="ServiceDiscoveryReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="SupportedServiceIDs" type="ServiceIDListType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="ServiceDiscoveryRes" type="ServiceDiscoveryResType"/>
+	<xs:complexType name="ServiceDiscoveryResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="ServiceRenegotiationSupported" type="xs:boolean"/>
+					<xs:element name="EnergyTransferServiceList" type="ServiceListType"/>
+					<xs:element name="VASList" type="ServiceListType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                -->
+	<!-- Service Detail -->
+	<!--                -->
+	<xs:element name="ServiceDetailReq" type="ServiceDetailReqType"/>
+	<xs:complexType name="ServiceDetailReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="ServiceID" type="serviceIDType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="ServiceDetailRes" type="ServiceDetailResType"/>
+	<xs:complexType name="ServiceDetailResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="ServiceID" type="serviceIDType"/>
+					<xs:element name="ServiceParameterList" type="ServiceParameterListType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                   -->
+	<!-- Service Selection -->
+	<!--                   -->
+	<xs:element name="ServiceSelectionReq" type="ServiceSelectionReqType"/>
+	<xs:complexType name="ServiceSelectionReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="SelectedEnergyTransferService" type="SelectedServiceType"/>
+					<xs:element name="SelectedVASList" type="SelectedServiceListType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="ServiceSelectionRes" type="ServiceSelectionResType"/>
+	<xs:complexType name="ServiceSelectionResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                   -->
+	<!-- Schedule Exchange -->
+	<!--                   -->
+	<xs:element name="ScheduleExchangeReq" type="ScheduleExchangeReqType"/>
+	<xs:complexType name="ScheduleExchangeReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="MaximumSupportingPoints" type="maxSupportingPointsScheduleTupleType"/>
+					<xs:choice>
+						<xs:element name="Dynamic_SEReqControlMode" type="Dynamic_SEReqControlModeType"/>
+						<xs:element name="Scheduled_SEReqControlMode" type="Scheduled_SEReqControlModeType"/>
+					</xs:choice>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="ScheduleExchangeRes" type="ScheduleExchangeResType"/>
+	<xs:complexType name="ScheduleExchangeResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="GoToPause" type="xs:boolean" minOccurs="0"/>
+					<xs:choice>
+						<xs:element name="Dynamic_SEResControlMode" type="Dynamic_SEResControlModeType"/>
+						<xs:element name="Scheduled_SEResControlMode" type="Scheduled_SEResControlModeType"/>
+					</xs:choice>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                -->
+	<!-- Power Delivery -->
+	<!--                -->
+	<xs:element name="PowerDeliveryReq" type="PowerDeliveryReqType"/>
+	<xs:complexType name="PowerDeliveryReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="ChargeProgress" type="chargeProgressType"/>
+					<xs:element name="EVPowerProfile" type="EVPowerProfileType" minOccurs="0"/>
+					<xs:element name="BPT_ChannelSelection" type="channelSelectionType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="PowerDeliveryRes" type="PowerDeliveryResType"/>
+	<xs:complexType name="PowerDeliveryResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEStatus" type="v2gci_ct:EVSEStatusType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                       -->
+	<!-- Metering Confirmation -->
+	<!--                       -->
+	<xs:element name="MeteringConfirmationReq" type="MeteringConfirmationReqType"/>
+	<xs:complexType name="MeteringConfirmationReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="SignedMeteringData" type="SignedMeteringDataType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="MeteringConfirmationRes" type="MeteringConfirmationResType"/>
+	<xs:complexType name="MeteringConfirmationResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--              -->
+	<!-- Session Stop -->
+	<!--              -->
+	<xs:element name="SessionStopReq" type="SessionStopReqType"/>
+	<xs:complexType name="SessionStopReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="ChargingSession" type="chargingSessionType"/>
+					<xs:element name="EVTerminationCode" type="v2gci_ct:nameType" minOccurs="0"/>
+					<xs:element name="EVTerminationExplanation" type="v2gci_ct:descriptionType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="SessionStopRes" type="SessionStopResType"/>
+	<xs:complexType name="SessionStopResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                          -->
+	<!-- Certificate Installation -->
+	<!--                          -->
+	<xs:element name="CertificateInstallationReq" type="CertificateInstallationReqType"/>
+	<xs:complexType name="CertificateInstallationReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="OEMProvisioningCertificateChain" type="SignedCertificateChainType"/>
+					<xs:element name="ListOfRootCertificateIDs" type="v2gci_ct:ListOfRootCertificateIDsType"/>
+					<xs:element name="MaximumContractCertificateChains" type="xs:unsignedByte"/>
+					<xs:element name="PrioritizedEMAIDs" type="EMAIDListType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="CertificateInstallationRes" type="CertificateInstallationResType"/>
+	<xs:complexType name="CertificateInstallationResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="CPSCertificateChain" type="CertificateChainType"/>
+					<xs:element name="SignedInstallationData" type="SignedInstallationDataType"/>
+					<xs:element name="RemainingContractCertificateChains" type="xs:unsignedByte"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                  -->
+	<!-- Vehicle Check In -->
+	<!--                  -->
+	<xs:element name="VehicleCheckInReq" type="VehicleCheckInReqType"/>
+	<xs:complexType name="VehicleCheckInReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVCheckInStatus" type="evCheckInStatusType"/>
+					<xs:element name="ParkingMethod" type="parkingMethodType"/>
+					<xs:element name="VehicleFrame" type="xs:short" minOccurs="0"/>
+					<xs:element name="DeviceOffset" type="xs:short" minOccurs="0"/>
+					<xs:element name="VehicleTravel" type="xs:short" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="VehicleCheckInRes" type="VehicleCheckInResType"/>
+	<xs:complexType name="VehicleCheckInResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="ParkingSpace" type="xs:short" minOccurs="0"/>
+					<xs:element name="DeviceLocation" type="xs:short" minOccurs="0"/>
+					<xs:element name="TargetDistance" type="xs:short" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                   -->
+	<!-- Vehicle Check Out -->
+	<!--                   -->
+	<xs:element name="VehicleCheckOutReq" type="VehicleCheckOutReqType"/>
+	<xs:complexType name="VehicleCheckOutReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVCheckOutStatus" type="evCheckOutStatusType"/>
+					<xs:element name="CheckOutTime" type="xs:unsignedLong"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="VehicleCheckOutRes" type="VehicleCheckOutResType"/>
+	<xs:complexType name="VehicleCheckOutResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSECheckOutStatus" type="evseCheckOutStatusType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- –––––––––––––––––––––– -->
+	<!-- Message Specific Types -->
+	<!-- –––––––––––––––––––––– -->
+	<!--                     -->
+	<!-- Authorization Setup -->
+	<!--                     -->
+	<xs:simpleType name="authorizationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EIM"/>
+			<xs:enumeration value="PnC"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="genChallengeType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:length value="16"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Identification Mode / PnC -->
+	<xs:complexType name="PnC_ASResAuthorizationModeType">
+		<xs:sequence>
+			<xs:element name="GenChallenge" type="genChallengeType"/>
+			<xs:element name="SupportedProviders" type="SupportedProvidersListType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SupportedProvidersListType">
+		<xs:sequence>
+			<xs:element name="ProviderID" type="v2gci_ct:nameType" maxOccurs="128"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- Identification Mode / EIM -->
+	<xs:complexType name="EIM_ASResAuthorizationModeType"/>
+	<!--               -->
+	<!-- Authorization -->
+	<!--               -->
+	<!-- Identification Mode / PnC -->
+	<xs:complexType name="PnC_AReqAuthorizationModeType">
+		<xs:sequence>
+			<xs:element name="GenChallenge" type="genChallengeType"/>
+			<xs:element name="ContractCertificateChain" type="ContractCertificateChainType"/>
+		</xs:sequence>
+		<xs:attribute name="Id" type="xs:ID" use="required"/>
+	</xs:complexType>
+	<!-- Identification Mode / EIM -->
+	<xs:complexType name="EIM_AReqAuthorizationModeType"/>
+	<!--                                                        -->
+	<!-- Service Discovery / Service Detail / Service Selection -->
+	<!--                                                        -->
+	<xs:simpleType name="serviceIDType">
+		<xs:restriction base="xs:unsignedShort"/>
+	</xs:simpleType>
+	<xs:complexType name="ServiceIDListType">
+		<xs:sequence>
+			<xs:element name="ServiceID" type="serviceIDType" maxOccurs="16"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceType">
+		<xs:sequence>
+			<xs:element name="ServiceID" type="serviceIDType"/>
+			<xs:element name="FreeService" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceListType">
+		<xs:sequence>
+			<xs:element name="Service" type="ServiceType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SelectedServiceType">
+		<xs:sequence>
+			<xs:element name="ServiceID" type="serviceIDType"/>
+			<xs:element name="ParameterSetID" type="serviceIDType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SelectedServiceListType">
+		<xs:sequence>
+			<xs:element name="SelectedService" type="SelectedServiceType" maxOccurs="16"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ParameterType">
+		<xs:choice>
+			<xs:element name="boolValue" type="xs:boolean"/>
+			<xs:element name="byteValue" type="xs:byte"/>
+			<xs:element name="shortValue" type="xs:short"/>
+			<xs:element name="intValue" type="xs:int"/>
+			<xs:element name="rationalNumber" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="finiteString" type="v2gci_ct:nameType"/>
+		</xs:choice>
+		<xs:attribute name="Name" type="v2gci_ct:nameType" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="ParameterSetType">
+		<xs:sequence>
+			<xs:element name="ParameterSetID" type="serviceIDType"/>
+			<xs:element name="Parameter" type="ParameterType" maxOccurs="32"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceParameterListType">
+		<xs:sequence>
+			<xs:element name="ParameterSet" type="ParameterSetType" maxOccurs="32"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--                   -->
+	<!-- Schedule Exchange -->
+	<!--                   -->
+	<xs:simpleType name="maxSupportingPointsScheduleTupleType">
+		<xs:restriction base="xs:unsignedShort">
+			<xs:minInclusive value="12"/>
+			<xs:maxInclusive value="1024"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ScheduleTupleType -->
+	<xs:complexType name="ScheduleTupleType">
+		<xs:sequence>
+			<xs:element name="ScheduleTupleID" type="v2gci_ct:numericIDType"/>
+			<xs:element name="ChargingSchedule" type="ChargingScheduleType"/>
+			<xs:element name="DischargingSchedule" type="ChargingScheduleType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- ScheduleTupleType/ChargingScheduleType -->
+	<xs:complexType name="ChargingScheduleType">
+		<xs:sequence>
+			<xs:element name="PowerSchedule" type="PowerScheduleType"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="AbsolutePriceSchedule" type="AbsolutePriceScheduleType"/>
+				<xs:element name="PriceLevelSchedule" type="PriceLevelScheduleType"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- Control Modes - Scheduled -->
+	<xs:complexType name="Scheduled_SEReqControlModeType">
+		<xs:sequence>
+			<xs:element name="DepartureTime" type="xs:unsignedInt" minOccurs="0"/>
+			<xs:element name="EVTargetEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVMaximumEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVMinimumEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVEnergyOffer" type="EVEnergyOfferType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Scheduled_SEResControlModeType">
+		<xs:sequence>
+			<xs:element name="ScheduleTuple" type="ScheduleTupleType" maxOccurs="3"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- Control Modes - Dynamic -->
+	<xs:complexType name="Dynamic_SEReqControlModeType">
+		<xs:sequence>
+			<xs:element name="DepartureTime" type="xs:unsignedInt"/>
+			<xs:element name="MinimumSOC" type="v2gci_ct:percentValueType" minOccurs="0"/>
+			<xs:element name="TargetSOC" type="v2gci_ct:percentValueType" minOccurs="0"/>
+			<xs:element name="EVTargetEnergyRequest" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMaximumEnergyRequest" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMinimumEnergyRequest" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMaximumV2XEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="EVMinimumV2XEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Dynamic_SEResControlModeType">
+		<xs:sequence>
+			<xs:element name="DepartureTime" type="xs:unsignedInt" minOccurs="0"/>
+			<xs:element name="MinimumSOC" type="v2gci_ct:percentValueType" minOccurs="0"/>
+			<xs:element name="TargetSOC" type="v2gci_ct:percentValueType" minOccurs="0"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="AbsolutePriceSchedule" type="AbsolutePriceScheduleType"/>
+				<xs:element name="PriceLevelSchedule" type="PriceLevelScheduleType"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<!--                -->
+	<!-- Power Delivery -->
+	<!--                -->
+	<xs:simpleType name="chargeProgressType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Start"/>
+			<xs:enumeration value="Stop"/>
+			<xs:enumeration value="Standby"/>
+			<xs:enumeration value="ScheduleRenegotiation"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="channelSelectionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Charge"/>
+			<xs:enumeration value="Discharge"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--                          -->
+	<!-- Certificate Installation -->
+	<!--                          -->
+	<xs:simpleType name="ecdhCurveType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SECP521"/>
+			<xs:enumeration value="X448"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="dhPublicKeyType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:length value="133"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="secp521_EncryptedPrivateKeyType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:length value="94"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="x448_EncryptedPrivateKeyType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:length value="84"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpm_EncryptedPrivateKeyType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:length value="206"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="SignedInstallationDataType">
+		<xs:sequence>
+			<xs:element name="ContractCertificateChain" type="ContractCertificateChainType"/>
+			<xs:element name="ECDHCurve" type="ecdhCurveType"/>
+			<xs:element name="DHPublicKey" type="dhPublicKeyType"/>
+			<xs:choice>
+				<xs:element name="SECP521_EncryptedPrivateKey" type="secp521_EncryptedPrivateKeyType"/>
+				<xs:element name="X448_EncryptedPrivateKey" type="x448_EncryptedPrivateKeyType"/>
+				<xs:element name="TPM_EncryptedPrivateKey" type="tpm_EncryptedPrivateKeyType"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="Id" type="xs:ID" use="required"/>
+	</xs:complexType>
+	<xs:element name="SignedInstallationData" type="SignedInstallationDataType"/>
+	<!--                       -->
+	<!-- Metering Confirmation -->
+	<!--                       -->
+	<xs:complexType name="SignedMeteringDataType">
+		<xs:sequence>
+			<xs:element name="SessionID" type="v2gci_ct:sessionIDType"/>
+			<xs:element name="MeterInfo" type="v2gci_ct:MeterInfoType"/>
+			<xs:element name="Receipt" type="v2gci_ct:ReceiptType" minOccurs="0"/>
+			<xs:choice>
+				<xs:element name="Dynamic_SMDTControlMode" type="Dynamic_SMDTControlModeType"/>
+				<xs:element name="Scheduled_SMDTControlMode" type="Scheduled_SMDTControlModeType"/>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="Id" type="xs:ID" use="required"/>
+	</xs:complexType>
+	<xs:element name="SignedMeteringData" type="SignedMeteringDataType"/>
+	<!-- Control Modes - Scheduled -->
+	<xs:complexType name="Scheduled_SMDTControlModeType">
+		<xs:sequence>
+			<xs:element name="SelectedScheduleTupleID" type="v2gci_ct:numericIDType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- Control Modes - Dynamic -->
+	<xs:complexType name="Dynamic_SMDTControlModeType"/>
+	<!--             -->
+	<!-- SessionStop -->
+	<!--             -->
+	<xs:simpleType name="chargingSessionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Pause"/>
+			<xs:enumeration value="Terminate"/>
+			<xs:enumeration value="ServiceRenegotiation"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--                        -->
+	<!-- Vehicle Check In / Out -->
+	<!--                        -->
+	<xs:simpleType name="evCheckInStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CheckIn"/>
+			<xs:enumeration value="Processing"/>
+			<xs:enumeration value="Completed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="evCheckOutStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CheckOut"/>
+			<xs:enumeration value="Processing"/>
+			<xs:enumeration value="Completed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="evseCheckOutStatusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Scheduled"/>
+			<xs:enumeration value="Completed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="parkingMethodType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AutoParking"/>
+			<xs:enumeration value="MVGuideManual"/>
+			<xs:enumeration value="Manual"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TargetPositionType">
+		<xs:sequence>
+			<xs:element name="TargetOffsetX" type="xs:unsignedShort"/>
+			<xs:element name="TargetOffsetY" type="xs:unsignedShort"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- –––––––––––––– -->
+	<!-- Schedule Types -->
+	<!-- –––––––––––––– -->
+	<!--                   -->
+	<!-- PowerScheduleType -->
+	<!--                   -->
+	<xs:complexType name="PowerScheduleType">
+		<xs:sequence>
+			<xs:element name="TimeAnchor" type="xs:unsignedLong"/>
+			<xs:element name="AvailableEnergy" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="PowerTolerance" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="PowerScheduleEntries" type="PowerScheduleEntryListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- PowerScheduleType/PowerScheduleEntryListType -->
+	<xs:complexType name="PowerScheduleEntryListType">
+		<xs:sequence>
+			<xs:element name="PowerScheduleEntry" type="PowerScheduleEntryType" maxOccurs="1024"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- PowerScheduleType/PowerScheduleEntryListType/PowerScheduleEntryType -->
+	<xs:complexType name="PowerScheduleEntryType">
+		<xs:sequence>
+			<xs:element name="Duration" type="xs:unsignedInt"/>
+			<xs:element name="Power" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="Power_L2" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="Power_L3" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--                   -->
+	<!-- PriceScheduleType -->
+	<!--                   -->
+	<xs:complexType name="PriceScheduleType" abstract="true">
+		<xs:sequence>
+			<xs:element name="TimeAnchor" type="xs:unsignedLong"/>
+			<xs:element name="PriceScheduleID" type="v2gci_ct:numericIDType"/>
+			<xs:element name="PriceScheduleDescription" type="v2gci_ct:descriptionType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- PriceLevelScheduleType -->
+	<xs:complexType name="PriceLevelScheduleType">
+		<xs:complexContent>
+			<xs:extension base="PriceScheduleType">
+				<xs:sequence>
+					<xs:element name="NumberOfPriceLevels" type="xs:unsignedByte"/>
+					<xs:element name="PriceLevelScheduleEntries" type="PriceLevelScheduleEntryListType"/>
+				</xs:sequence>
+				<xs:attribute name="Id" type="xs:ID"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- PriceLevelScheduleType/PriceLevelScheduleEntryListType -->
+	<xs:complexType name="PriceLevelScheduleEntryListType">
+		<xs:sequence>
+			<xs:element name="PriceLevelScheduleEntry" type="PriceLevelScheduleEntryType" maxOccurs="1024"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- PriceLevelScheduleType/PriceLevelScheduleEntryListType/PriceLevelScheduleEntryType -->
+	<xs:complexType name="PriceLevelScheduleEntryType">
+		<xs:sequence>
+			<xs:element name="Duration" type="xs:unsignedInt"/>
+			<xs:element name="PriceLevel" type="xs:unsignedByte"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType -->
+	<xs:complexType name="AbsolutePriceScheduleType">
+		<xs:complexContent>
+			<xs:extension base="PriceScheduleType">
+				<xs:sequence>
+					<xs:element name="Currency" type="currencyType"/>
+					<xs:element name="Language" type="languageType"/>
+					<xs:element name="PriceAlgorithm" type="v2gci_ct:identifierType"/>
+					<xs:element name="MinimumCost" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="MaximumCost" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="TaxRules" type="TaxRuleListType" minOccurs="0"/>
+					<xs:element name="PriceRuleStacks" type="PriceRuleStackListType"/>
+					<xs:element name="OverstayRules" type="OverstayRuleListType" minOccurs="0"/>
+					<xs:element name="AdditionalSelectedServices" type="AdditionalServiceListType" minOccurs="0"/>
+				</xs:sequence>
+				<xs:attribute name="Id" type="xs:ID"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/TaxRuleListType -->
+	<xs:complexType name="TaxRuleListType">
+		<xs:sequence>
+			<xs:element name="TaxRule" type="TaxRuleType" maxOccurs="10"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/TaxRuleListType/TaxRuleType -->
+	<xs:complexType name="TaxRuleType">
+		<xs:sequence>
+			<xs:element name="TaxRuleID" type="v2gci_ct:numericIDType"/>
+			<xs:element name="TaxRuleName" type="v2gci_ct:nameType" minOccurs="0"/>
+			<xs:element name="TaxRate" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="TaxIncludedInPrice" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="AppliesToEnergyFee" type="xs:boolean"/>
+			<xs:element name="AppliesToParkingFee" type="xs:boolean"/>
+			<xs:element name="AppliesToOverstayFee" type="xs:boolean"/>
+			<xs:element name="AppliesMinimumMaximumCost" type="xs:boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/PriceRuleStackListType -->
+	<xs:complexType name="PriceRuleStackListType">
+		<xs:sequence>
+			<xs:element name="PriceRuleStack" type="PriceRuleStackType" maxOccurs="1024"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/PriceRuleListType/PriceRuleStackType -->
+	<xs:complexType name="PriceRuleStackType">
+		<xs:sequence>
+			<xs:element name="Duration" type="xs:unsignedInt"/>
+			<xs:element name="PriceRule" type="PriceRuleType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/PriceRuleListType/PriceRuleStackType/PriceRuleType -->
+	<xs:complexType name="PriceRuleType">
+		<xs:sequence>
+			<xs:element name="EnergyFee" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="ParkingFee" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="ParkingFeePeriod" type="xs:unsignedInt" minOccurs="0"/>
+			<xs:element name="CarbonDioxideEmission" type="xs:unsignedShort" minOccurs="0"/>
+			<xs:element name="RenewableGenerationPercentage" type="xs:unsignedByte" minOccurs="0"/>
+			<xs:element name="PowerRangeStart" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/OverstayRuleListType -->
+	<xs:complexType name="OverstayRuleListType">
+		<xs:sequence>
+			<xs:element name="OverstayTimeThreshold" type="xs:unsignedInt" minOccurs="0"/>
+			<xs:element name="OverstayPowerThreshold" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+			<xs:element name="OverstayRule" type="OverstayRuleType" maxOccurs="5"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/OverstayRuleListType/OverstayRuleType -->
+	<xs:complexType name="OverstayRuleType">
+		<xs:sequence>
+			<xs:element name="OverstayRuleDescription" type="v2gci_ct:descriptionType" minOccurs="0"/>
+			<xs:element name="StartTime" type="xs:unsignedInt"/>
+			<xs:element name="OverstayFee" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="OverstayFeePeriod" type="xs:unsignedInt"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- AbsolutePriceScheduleType/AdditionalServicesListType -->
+	<xs:complexType name="AdditionalServiceListType">
+		<xs:sequence>
+			<xs:element name="AdditionalService" type="AdditionalServiceType" maxOccurs="5"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- this allows for additional services -->
+	<xs:complexType name="AdditionalServiceType">
+		<xs:sequence>
+			<xs:element name="ServiceName" type="v2gci_ct:nameType"/>
+			<xs:element name="ServiceFee" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="currencyType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="languageType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--                  -->
+	<!-- EV Power Profile -->
+	<!--                  -->
+	<xs:complexType name="EVPowerProfileEntryListType">
+		<xs:sequence>
+			<xs:element name="EVPowerProfileEntry" type="PowerScheduleEntryType" maxOccurs="2048"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVPowerProfileType">
+		<xs:sequence>
+			<xs:element name="TimeAnchor" type="xs:unsignedLong"/>
+			<xs:choice>
+				<xs:element name="Dynamic_EVPPTControlMode" type="Dynamic_EVPPTControlModeType"/>
+				<xs:element name="Scheduled_EVPPTControlMode" type="Scheduled_EVPPTControlModeType"/>
+			</xs:choice>
+			<xs:element name="EVPowerProfileEntries" type="EVPowerProfileEntryListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- Control Modes - Scheduled -->
+	<xs:complexType name="Scheduled_EVPPTControlModeType">
+		<xs:sequence>
+			<xs:element name="SelectedScheduleTupleID" type="v2gci_ct:numericIDType"/>
+			<xs:element name="PowerToleranceAcceptance" type="powerToleranceAcceptanceType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="powerToleranceAcceptanceType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="PowerToleranceNotConfirmed"/>
+			<xs:enumeration value="PowerToleranceConfirmed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Control Modes - Dynamic -->
+	<xs:complexType name="Dynamic_EVPPTControlModeType"/>
+	<!--                 -->
+	<!-- EV Energy Offer -->
+	<!--                 -->
+	<xs:complexType name="EVEnergyOfferType">
+		<xs:sequence>
+			<xs:element name="EVPowerSchedule" type="EVPowerScheduleType"/>
+			<xs:element name="EVAbsolutePriceSchedule" type="EVAbsolutePriceScheduleType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVPowerScheduleType">
+		<xs:sequence>
+			<xs:element name="TimeAnchor" type="xs:unsignedLong"/>
+			<xs:element name="EVPowerScheduleEntries" type="EVPowerScheduleEntryListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVPowerScheduleEntryListType">
+		<xs:sequence>
+			<xs:element name="EVPowerScheduleEntry" type="EVPowerScheduleEntryType" maxOccurs="1024"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVPowerScheduleEntryType">
+		<xs:sequence>
+			<xs:element name="Duration" type="xs:unsignedInt"/>
+			<xs:element name="Power" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVAbsolutePriceScheduleType">
+		<xs:sequence>
+			<xs:element name="TimeAnchor" type="xs:unsignedLong"/>
+			<xs:element name="Currency" type="currencyType"/>
+			<xs:element name="PriceAlgorithm" type="v2gci_ct:identifierType"/>
+			<xs:element name="EVPriceRuleStacks" type="EVPriceRuleStackListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVPriceRuleStackListType">
+		<xs:sequence>
+			<xs:element name="EVPriceRuleStack" type="EVPriceRuleStackType" maxOccurs="1024"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVPriceRuleStackType">
+		<xs:sequence>
+			<xs:element name="Duration" type="xs:unsignedInt"/>
+			<xs:element name="EVPriceRule" type="EVPriceRuleType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVPriceRuleType">
+		<xs:sequence>
+			<xs:element name="EnergyFee" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="PowerRangeStart" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- ––––––––––––––––– -->
+	<!-- Certificate Types -->
+	<!-- ––––––––––––––––– -->
+	<xs:simpleType name="certificateType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:maxLength value="1600"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="EMAIDListType">
+		<xs:sequence>
+			<xs:element name="EMAID" type="v2gci_ct:identifierType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SubCertificatesType">
+		<xs:sequence>
+			<xs:element name="Certificate" type="certificateType" maxOccurs="3"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CertificateChainType">
+		<xs:sequence>
+			<xs:element name="Certificate" type="certificateType"/>
+			<xs:element name="SubCertificates" type="SubCertificatesType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SignedCertificateChainType">
+		<xs:sequence>
+			<xs:element name="Certificate" type="certificateType"/>
+			<xs:element name="SubCertificates" type="SubCertificatesType" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="Id" type="xs:ID" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="ContractCertificateChainType">
+		<xs:sequence>
+			<xs:element name="Certificate" type="certificateType"/>
+			<xs:element name="SubCertificates" type="SubCertificatesType"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/tools/schemas/iso20/V2G_CI_CommonTypes.xsd
+++ b/tools/schemas/iso20/V2G_CI_CommonTypes.xsd
@@ -1,0 +1,321 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:iso:std:iso:15118:-20:CommonTypes" xmlns:xmlsig="http://www.w3.org/2000/09/xmldsig#" targetNamespace="urn:iso:std:iso:15118:-20:CommonTypes" elementFormDefault="qualified" attributeFormDefault="qualified" version="15118:-20">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema.xsd"/>
+	<!--                     -->
+	<!-- ––––––––––––––––––– -->
+	<!-- Basic Message Types -->
+	<!-- ––––––––––––––––––– -->
+	<!--        -->
+	<!-- Header -->
+	<!--        -->
+	<xs:complexType name="MessageHeaderType">
+		<xs:sequence>
+			<xs:element name="SessionID" type="sessionIDType"/>
+			<xs:element name="TimeStamp" type="xs:unsignedLong"/>
+			<xs:element ref="xmlsig:Signature" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--             -->
+	<!-- V2G Message -->
+	<!--             -->
+	<xs:complexType name="V2GMessageType" abstract="true">
+		<xs:sequence>
+			<xs:element name="Header" type="MessageHeaderType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--                          -->
+	<!-- V2G Request and Response -->
+	<!--                          -->
+	<xs:complexType name="V2GRequestType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="V2GMessageType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="V2GResponseType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="V2GMessageType">
+				<xs:sequence>
+					<xs:element name="ResponseCode" type="responseCodeType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                            -->
+	<!-- Charge Parameter Discovery -->
+	<!--                            -->
+	<xs:complexType name="ChargeParameterDiscoveryReqType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="V2GRequestType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChargeParameterDiscoveryResType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="V2GResponseType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--             -->
+	<!-- Charge Loop -->
+	<!--             -->
+	<xs:complexType name="ChargeLoopReqType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="V2GRequestType">
+				<xs:sequence>
+					<xs:element name="DisplayParameters" type="DisplayParametersType" minOccurs="0"/>
+					<xs:element name="MeterInfoRequested" type="xs:boolean"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ChargeLoopResType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEStatus" type="EVSEStatusType" minOccurs="0"/>
+					<xs:element name="MeterInfo" type="MeterInfoType" minOccurs="0"/>
+					<xs:element name="Receipt" type="ReceiptType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                        -->
+	<!-- –––––––––––––––––––––– -->
+	<!-- Message Specific Types -->
+	<!-- –––––––––––––––––––––– -->
+	<!--             -->
+	<!-- Charge Loop -->
+	<!--             -->
+	<!-- Control Modes -->
+	<xs:element name="CLReqControlMode" type="CLReqControlModeType"/>
+	<xs:complexType name="CLReqControlModeType" abstract="true"/>
+	<xs:element name="CLResControlMode" type="CLResControlModeType"/>
+	<xs:complexType name="CLResControlModeType" abstract="true"/>
+	<!-- Control Modes - Scheduled -->
+	<xs:complexType name="Scheduled_CLReqControlModeType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVTargetEnergyRequest" type="RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumEnergyRequest" type="RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumEnergyRequest" type="RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Scheduled_CLResControlModeType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="CLResControlModeType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- Control Modes - Dynamic -->
+	<xs:complexType name="Dynamic_CLReqControlModeType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="DepartureTime" type="xs:unsignedInt" minOccurs="0"/>
+					<xs:element name="EVTargetEnergyRequest" type="RationalNumberType"/>
+					<xs:element name="EVMaximumEnergyRequest" type="RationalNumberType"/>
+					<xs:element name="EVMinimumEnergyRequest" type="RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Dynamic_CLResControlModeType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="CLResControlModeType">
+				<xs:sequence>
+					<xs:element name="DepartureTime" type="xs:unsignedInt" minOccurs="0"/>
+					<xs:element name="MinimumSOC" type="percentValueType" minOccurs="0"/>
+					<xs:element name="TargetSOC" type="percentValueType" minOccurs="0"/>
+					<xs:element name="AckMaxDelay" type="xs:unsignedShort" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- ––––––––––––––––––– -->
+	<!-- Common Simple Types -->
+	<!-- ––––––––––––––––––– -->
+	<!-- Binary Types -->
+	<!-- ID Types -->
+	<xs:simpleType name="numericIDType">
+		<xs:restriction base="xs:unsignedInt">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="4294967295"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="sessionIDType">
+		<xs:restriction base="xs:hexBinary">
+			<xs:length value="8"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Enumerations -->
+	<xs:simpleType name="evseNotificationType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Pause"/>
+			<xs:enumeration value="ExitStandby"/>
+			<xs:enumeration value="Terminate"/>
+			<xs:enumeration value="ScheduleRenegotiation"/>
+			<xs:enumeration value="ServiceRenegotiation"/>
+			<xs:enumeration value="MeteringConfirmation"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="processingType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Finished"/>
+			<xs:enumeration value="Ongoing"/>
+			<xs:enumeration value="Ongoing_WaitingForCustomerInteraction"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="responseCodeType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="OK"/>
+			<xs:enumeration value="OK_CertificateExpiresSoon"/>
+			<xs:enumeration value="OK_NewSessionEstablished"/>
+			<xs:enumeration value="OK_OldSessionJoined"/>
+			<xs:enumeration value="OK_PowerToleranceConfirmed"/>
+			<xs:enumeration value="WARNING_AuthorizationSelectionInvalid"/>
+			<xs:enumeration value="WARNING_CertificateExpired"/>
+			<xs:enumeration value="WARNING_CertificateNotYetValid"/>
+			<xs:enumeration value="WARNING_CertificateRevoked"/>
+			<xs:enumeration value="WARNING_CertificateValidationError"/>
+			<xs:enumeration value="WARNING_ChallengeInvalid"/>
+			<xs:enumeration value="WARNING_EIMAuthorizationFailure"/>
+			<xs:enumeration value="WARNING_eMSPUnknown"/>
+			<xs:enumeration value="WARNING_EVPowerProfileViolation"/>
+			<xs:enumeration value="WARNING_GeneralPnCAuthorizationError"/>
+			<xs:enumeration value="WARNING_NoCertificateAvailable"/>
+			<xs:enumeration value="WARNING_NoContractMatchingPCIDFound"/>
+			<xs:enumeration value="WARNING_PowerToleranceNotConfirmed"/>
+			<xs:enumeration value="WARNING_ScheduleRenegotiationFailed"/>
+			<xs:enumeration value="WARNING_StandbyNotAllowed"/>
+			<xs:enumeration value="WARNING_WPT"/>
+			<xs:enumeration value="FAILED"/>
+			<xs:enumeration value="FAILED_AssociationError"/>
+			<xs:enumeration value="FAILED_ContactorError"/>
+			<xs:enumeration value="FAILED_EVPowerProfileInvalid"/>
+			<xs:enumeration value="FAILED_EVPowerProfileViolation"/>
+			<xs:enumeration value="FAILED_MeteringSignatureNotValid"/>
+			<xs:enumeration value="FAILED_NoEnergyTransferServiceSelected"/>
+			<xs:enumeration value="FAILED_NoServiceRenegotiationSupported"/>
+			<xs:enumeration value="FAILED_PauseNotAllowed"/>
+			<xs:enumeration value="FAILED_PowerDeliveryNotApplied"/>
+			<xs:enumeration value="FAILED_PowerToleranceNotConfirmed"/>
+			<xs:enumeration value="FAILED_ScheduleRenegotiation"/>
+			<xs:enumeration value="FAILED_ScheduleSelectionInvalid"/>
+			<xs:enumeration value="FAILED_SequenceError"/>
+			<xs:enumeration value="FAILED_ServiceIDInvalid"/>
+			<xs:enumeration value="FAILED_ServiceSelectionInvalid"/>
+			<xs:enumeration value="FAILED_SignatureError"/>
+			<xs:enumeration value="FAILED_UnknownSession"/>
+			<xs:enumeration value="FAILED_WrongChargeParameter"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Integers -->
+	<xs:simpleType name="percentValueType">
+		<xs:restriction base="xs:byte">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Strings -->
+	<xs:simpleType name="identifierType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="nameType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="80"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="descriptionType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="160"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- –––––––––––––––––––– -->
+	<!-- Common Complex Types -->
+	<!-- –––––––––––––––––––– -->
+	<xs:complexType name="DisplayParametersType">
+		<xs:sequence>
+			<xs:element name="PresentSOC" type="percentValueType" minOccurs="0"/>
+			<xs:element name="MinimumSOC" type="percentValueType" minOccurs="0"/>
+			<xs:element name="TargetSOC" type="percentValueType" minOccurs="0"/>
+			<xs:element name="MaximumSOC" type="percentValueType" minOccurs="0"/>
+			<xs:element name="RemainingTimeToMinimumSOC" type="xs:unsignedInt" minOccurs="0"/>
+			<xs:element name="RemainingTimeToTargetSOC" type="xs:unsignedInt" minOccurs="0"/>
+			<xs:element name="RemainingTimeToMaximumSOC" type="xs:unsignedInt" minOccurs="0"/>
+			<xs:element name="ChargingComplete" type="xs:boolean" minOccurs="0"/>
+			<xs:element name="BatteryEnergyCapacity" type="RationalNumberType" minOccurs="0"/>
+			<xs:element name="InletHot" type="xs:boolean" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="EVSEStatusType">
+		<xs:sequence>
+			<xs:element name="NotificationMaxDelay" type="xs:unsignedShort"/>
+			<xs:element name="EVSENotification" type="evseNotificationType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RationalNumberType">
+		<xs:sequence>
+			<xs:element name="Exponent" type="xs:byte"/>
+			<xs:element name="Value" type="xs:short"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- –––––––––––––– -->
+	<!-- Metering Types -->
+	<!-- –––––––––––––– -->
+	<xs:simpleType name="meterIDType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="32"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="meterSignatureType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:maxLength value="64"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="MeterInfoType">
+		<xs:sequence>
+			<xs:element name="MeterID" type="meterIDType"/>
+			<xs:element name="ChargedEnergyReadingWh" type="xs:unsignedLong"/>
+			<xs:element name="BPT_DischargedEnergyReadingWh" type="xs:unsignedLong" minOccurs="0"/>
+			<xs:element name="CapacitiveEnergyReadingVARh" type="xs:unsignedLong" minOccurs="0"/>
+			<xs:element name="BPT_InductiveEnergyReadingVARh" type="xs:unsignedLong" minOccurs="0"/>
+			<xs:element name="MeterSignature" type="meterSignatureType" minOccurs="0"/>
+			<xs:element name="MeterStatus" type="xs:short" minOccurs="0"/>
+			<xs:element name="MeterTimestamp" type="xs:unsignedLong" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- –––––––––––––––––––––– -->
+	<!-- Absolute Pricing Types -->
+	<!-- –––––––––––––––––––––– -->
+	<xs:complexType name="DetailedCostType">
+		<xs:sequence>
+			<xs:element name="Amount" type="RationalNumberType"/>
+			<xs:element name="CostPerUnit" type="RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DetailedTaxType">
+		<xs:sequence>
+			<xs:element name="TaxRuleID" type="numericIDType"/>
+			<xs:element name="Amount" type="RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReceiptType">
+		<xs:sequence>
+			<xs:element name="TimeAnchor" type="xs:unsignedLong"/>
+			<xs:element name="EnergyCosts" type="DetailedCostType" minOccurs="0"/>
+			<xs:element name="OccupancyCosts" type="DetailedCostType" minOccurs="0"/>
+			<xs:element name="AdditionalServicesCosts" type="DetailedCostType" minOccurs="0"/>
+			<xs:element name="OverstayCosts" type="DetailedCostType" minOccurs="0"/>
+			<xs:element name="TaxCosts" type="DetailedTaxType" minOccurs="0" maxOccurs="10"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- ––––––––––––––––––– -->
+	<!-- Authorization Types -->
+	<!-- ––––––––––––––––––– -->
+	<xs:complexType name="ListOfRootCertificateIDsType">
+		<xs:sequence>
+			<xs:element name="RootCertificateID" type="xmlsig:X509IssuerSerialType" maxOccurs="20"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/tools/schemas/iso20/V2G_CI_DC.xsd
+++ b/tools/schemas/iso20/V2G_CI_DC.xsd
@@ -1,0 +1,300 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:iso:std:iso:15118:-20:DC" xmlns:v2gci_ct="urn:iso:std:iso:15118:-20:CommonTypes" targetNamespace="urn:iso:std:iso:15118:-20:DC" elementFormDefault="qualified" attributeFormDefault="qualified" version="15118:-20">
+	<xs:import namespace="urn:iso:std:iso:15118:-20:CommonTypes" schemaLocation="V2G_CI_CommonTypes.xsd"/>
+	<!--             -->
+	<!-- ––––––––––– -->
+	<!-- DC Messages -->
+	<!-- ––––––––––– -->
+	<!--                               -->
+	<!-- DC Charge Parameter Discovery -->
+	<!--                               -->
+	<xs:element name="DC_ChargeParameterDiscoveryReq" type="DC_ChargeParameterDiscoveryReqType"/>
+	<xs:complexType name="DC_ChargeParameterDiscoveryReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeParameterDiscoveryReqType">
+				<xs:sequence>
+					<xs:element ref="DC_CPDReqEnergyTransferMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="DC_ChargeParameterDiscoveryRes" type="DC_ChargeParameterDiscoveryResType"/>
+	<xs:complexType name="DC_ChargeParameterDiscoveryResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeParameterDiscoveryResType">
+				<xs:sequence>
+					<xs:element ref="DC_CPDResEnergyTransferMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                -->
+	<!-- DC Cable Check -->
+	<!--                -->
+	<xs:element name="DC_CableCheckReq" type="DC_CableCheckReqType"/>
+	<xs:complexType name="DC_CableCheckReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="DC_CableCheckRes" type="DC_CableCheckResType"/>
+	<xs:complexType name="DC_CableCheckResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--               -->
+	<!-- DC Pre Charge -->
+	<!--               -->
+	<xs:element name="DC_PreChargeReq" type="DC_PreChargeReqType"/>
+	<xs:complexType name="DC_PreChargeReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="EVPresentVoltage" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVTargetVoltage" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="DC_PreChargeRes" type="DC_PreChargeResType"/>
+	<xs:complexType name="DC_PreChargeResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEPresentVoltage" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                -->
+	<!-- DC Charge Loop -->
+	<!--                -->
+	<xs:element name="DC_ChargeLoopReq" type="DC_ChargeLoopReqType"/>
+	<xs:complexType name="DC_ChargeLoopReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeLoopReqType">
+				<xs:sequence>
+					<xs:element name="EVPresentVoltage" type="v2gci_ct:RationalNumberType"/>
+					<xs:element ref="v2gci_ct:CLReqControlMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="DC_ChargeLoopRes" type="DC_ChargeLoopResType"/>
+	<xs:complexType name="DC_ChargeLoopResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeLoopResType">
+				<xs:sequence>
+					<xs:element name="EVSEPresentCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEPresentVoltage" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEPowerLimitAchieved" type="xs:boolean"/>
+					<xs:element name="EVSECurrentLimitAchieved" type="xs:boolean"/>
+					<xs:element name="EVSEVoltageLimitAchieved" type="xs:boolean"/>
+					<xs:element ref="v2gci_ct:CLResControlMode"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                      -->
+	<!-- DC Welding Detection -->
+	<!--                      -->
+	<xs:element name="DC_WeldingDetectionReq" type="DC_WeldingDetectionReqType"/>
+	<xs:complexType name="DC_WeldingDetectionReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVProcessing" type="v2gci_ct:processingType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="DC_WeldingDetectionRes" type="DC_WeldingDetectionResType"/>
+	<xs:complexType name="DC_WeldingDetectionResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEPresentVoltage" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                        -->
+	<!-- –––––––––––––––––––––– -->
+	<!-- Message Specific Types -->
+	<!-- –––––––––––––––––––––– -->
+	<!--                               -->
+	<!-- DC Charge Parameter Discovery -->
+	<!--                               -->
+	<!-- Energy Transfer Mode - DC -->
+	<xs:element name="DC_CPDReqEnergyTransferMode" type="DC_CPDReqEnergyTransferModeType"/>
+	<xs:complexType name="DC_CPDReqEnergyTransferModeType">
+		<xs:sequence>
+			<xs:element name="EVMaximumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMinimumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMaximumChargeCurrent" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMinimumChargeCurrent" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMaximumVoltage" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVMinimumVoltage" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="TargetSOC" type="v2gci_ct:percentValueType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="DC_CPDResEnergyTransferMode" type="DC_CPDResEnergyTransferModeType"/>
+	<xs:complexType name="DC_CPDResEnergyTransferModeType">
+		<xs:sequence>
+			<xs:element name="EVSEMaximumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEMinimumChargePower" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEMaximumChargeCurrent" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEMinimumChargeCurrent" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEMaximumVoltage" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEMinimumVoltage" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVSEPowerRampLimitation" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!-- Energy Transfer Mode - DC BPT -->
+	<xs:element name="BPT_DC_CPDReqEnergyTransferMode" type="BPT_DC_CPDReqEnergyTransferModeType" substitutionGroup="DC_CPDReqEnergyTransferMode"/>
+	<xs:complexType name="BPT_DC_CPDReqEnergyTransferModeType">
+		<xs:complexContent>
+			<xs:extension base="DC_CPDReqEnergyTransferModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumDischargeCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumDischargeCurrent" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="BPT_DC_CPDResEnergyTransferMode" type="BPT_DC_CPDResEnergyTransferModeType" substitutionGroup="DC_CPDResEnergyTransferMode"/>
+	<xs:complexType name="BPT_DC_CPDResEnergyTransferModeType">
+		<xs:complexContent>
+			<xs:extension base="DC_CPDResEnergyTransferModeType">
+				<xs:sequence>
+					<xs:element name="EVSEMaximumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMinimumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMaximumDischargeCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMinimumDischargeCurrent" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                -->
+	<!-- DC Charge Loop -->
+	<!--                -->
+	<!-- Control Modes - Scheduled -->
+	<xs:element name="Scheduled_DC_CLReqControlMode" type="Scheduled_DC_CLReqControlModeType" substitutionGroup="v2gci_ct:CLReqControlMode"/>
+	<xs:complexType name="Scheduled_DC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Scheduled_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVTargetCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVTargetVoltage" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumChargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumChargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumChargeCurrent" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumVoltage" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumVoltage" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="Scheduled_DC_CLResControlMode" type="Scheduled_DC_CLResControlModeType" substitutionGroup="v2gci_ct:CLResControlMode"/>
+	<xs:complexType name="Scheduled_DC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Scheduled_CLResControlModeType">
+				<xs:sequence>
+					<xs:element name="EVSEMaximumChargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMinimumChargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMaximumChargeCurrent" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMaximumVoltage" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- Control Modes - Scheduled - BPT -->
+	<xs:element name="BPT_Scheduled_DC_CLReqControlMode" type="BPT_Scheduled_DC_CLReqControlModeType" substitutionGroup="Scheduled_DC_CLReqControlMode"/>
+	<xs:complexType name="BPT_Scheduled_DC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Scheduled_DC_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumDischargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumDischargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMaximumDischargeCurrent" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="BPT_Scheduled_DC_CLResControlMode" type="BPT_Scheduled_DC_CLResControlModeType" substitutionGroup="Scheduled_DC_CLResControlMode"/>
+	<xs:complexType name="BPT_Scheduled_DC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Scheduled_DC_CLResControlModeType">
+				<xs:sequence>
+					<xs:element name="EVSEMaximumDischargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMinimumDischargePower" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMaximumDischargeCurrent" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVSEMinimumVoltage" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- Control Modes - Dynamic -->
+	<xs:element name="Dynamic_DC_CLReqControlMode" type="Dynamic_DC_CLReqControlModeType" substitutionGroup="v2gci_ct:CLReqControlMode"/>
+	<xs:complexType name="Dynamic_DC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Dynamic_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumChargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumChargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumChargeCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumVoltage" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumVoltage" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="Dynamic_DC_CLResControlMode" type="Dynamic_DC_CLResControlModeType" substitutionGroup="v2gci_ct:CLResControlMode"/>
+	<xs:complexType name="Dynamic_DC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:Dynamic_CLResControlModeType">
+				<xs:sequence>
+					<xs:element name="EVSEMaximumChargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMinimumChargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMaximumChargeCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMaximumVoltage" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!-- Control Modes - Dynamic - BPT -->
+	<xs:element name="BPT_Dynamic_DC_CLReqControlMode" type="BPT_Dynamic_DC_CLReqControlModeType" substitutionGroup="Dynamic_DC_CLReqControlMode"/>
+	<xs:complexType name="BPT_Dynamic_DC_CLReqControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Dynamic_DC_CLReqControlModeType">
+				<xs:sequence>
+					<xs:element name="EVMaximumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMinimumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumDischargeCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVMaximumV2XEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVMinimumV2XEnergyRequest" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="BPT_Dynamic_DC_CLResControlMode" type="BPT_Dynamic_DC_CLResControlModeType" substitutionGroup="Dynamic_DC_CLResControlMode"/>
+	<xs:complexType name="BPT_Dynamic_DC_CLResControlModeType">
+		<xs:complexContent>
+			<xs:extension base="Dynamic_DC_CLResControlModeType">
+				<xs:sequence>
+					<xs:element name="EVSEMaximumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMinimumDischargePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMaximumDischargeCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVSEMinimumVoltage" type="v2gci_ct:RationalNumberType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>

--- a/tools/schemas/iso20/V2G_CI_WPT.xsd
+++ b/tools/schemas/iso20/V2G_CI_WPT.xsd
@@ -1,0 +1,427 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:iso:std:iso:15118:-20:WPT" xmlns:v2gci_ct="urn:iso:std:iso:15118:-20:CommonTypes" targetNamespace="urn:iso:std:iso:15118:-20:WPT" elementFormDefault="qualified" attributeFormDefault="qualified" version="15118:-20">
+	<xs:import namespace="urn:iso:std:iso:15118:-20:CommonTypes" schemaLocation="V2G_CI_CommonTypes.xsd"/>
+	<!--              -->
+	<!-- –––––––––––– -->
+	<!-- WPT Messages -->
+	<!-- –––––––––––– -->
+	<!--                               -->
+	<!-- WPT Fine Positioning Setup -->
+	<!--                               -->
+	<xs:element name="WPT_FinePositioningSetupReq" type="WPT_FinePositioningSetupReqType"/>
+	<xs:complexType name="WPT_FinePositioningSetupReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="EVDeviceFinePositioningMethodList" type="WPT_FinePositioningMethodListType"/>
+					<xs:element name="EVDevicePairingMethodList" type="WPT_PairingMethodListType"/>
+					<xs:element name="EVDeviceAlignmentCheckMethodList" type="WPT_AlignmentCheckMethodListType"/>
+					<xs:element name="NaturalOffset" type="xs:unsignedShort"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+					<!-- optional LF System information -->
+					<xs:element name="LF_SystemSetupData" type="WPT_LF_SystemSetupDataType" minOccurs="0"/>
+					<!-- end LF System information -->
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="WPT_FinePositioningSetupRes" type="WPT_FinePositioningSetupResType"/>
+	<xs:complexType name="WPT_FinePositioningSetupResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="PrimaryDeviceFinePositioningMethodList" type="WPT_FinePositioningMethodListType"/>
+					<xs:element name="PrimaryDevicePairingMethodList" type="WPT_PairingMethodListType"/>
+					<xs:element name="PrimaryDeviceAlignmentCheckMethodList" type="WPT_AlignmentCheckMethodListType"/>
+					<xs:element name="NaturalOffset" type="xs:unsignedShort"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+					<!-- optional LF System information -->
+					<xs:element name="LF_SystemSetupData" type="WPT_LF_SystemSetupDataType" minOccurs="0"/>
+					<!-- end LF System information -->
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                         -->
+	<!-- WPT FinePositioning -->
+	<!--                         -->
+	<xs:element name="WPT_FinePositioningReq" type="WPT_FinePositioningReqType"/>
+	<xs:complexType name="WPT_FinePositioningReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="EVResultCode" type="WPT_EVResultType"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+					<!-- optional LF System information -->
+					<xs:element name="WPT_LF_DataPackageList" type="WPT_LF_DataPackageListType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="WPT_FinePositioningRes" type="WPT_FinePositioningResType"/>
+	<xs:complexType name="WPT_FinePositioningResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+					<!-- optional LF System information -->
+					<xs:element name="WPT_LF_DataPackageList" type="WPT_LF_DataPackageListType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--             -->
+	<!-- WPT Pairing -->
+	<!--             -->
+	<xs:element name="WPT_PairingReq" type="WPT_PairingReqType"/>
+	<xs:complexType name="WPT_PairingReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="ObservedIDCode" type="v2gci_ct:numericIDType" minOccurs="0"/>
+					<xs:element name="EVResultCode" type="WPT_EVResultType"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="WPT_PairingRes" type="WPT_PairingResType"/>
+	<xs:complexType name="WPT_PairingResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="ObservedIDCode" type="v2gci_ct:numericIDType" minOccurs="0"/>
+					<xs:element name="AlternativeSECCList" type="AlternativeSECCListType" minOccurs="0"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                                -->
+	<!-- WPT Charge Parameter Discovery -->
+	<!--                                -->
+	<xs:element name="WPT_ChargeParameterDiscoveryReq" type="WPT_ChargeParameterDiscoveryReqType"/>
+	<xs:complexType name="WPT_ChargeParameterDiscoveryReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeParameterDiscoveryReqType">
+				<xs:sequence>
+					<xs:element name="EVPCMaxReceivablePower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="SDMaxGroundClearence" type="xs:unsignedShort"/>
+					<xs:element name="SDMinGroundClearence" type="xs:unsignedShort"/>
+					<xs:element name="EVPCNaturalFrequency" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVPCDeviceLocalControl" type="xs:boolean"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="WPT_ChargeParameterDiscoveryRes" type="WPT_ChargeParameterDiscoveryResType"/>
+	<xs:complexType name="WPT_ChargeParameterDiscoveryResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeParameterDiscoveryResType">
+				<xs:sequence>
+					<xs:element name="PDInputPowerClass" type="WPT_PowerClassType"/>
+					<xs:element name="SDMinOutputPower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="SDMaxOutputPower" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="SDMaxGroundClearanceSupport" type="xs:unsignedShort"/>
+					<xs:element name="SDMinGroundClearanceSupport" type="xs:unsignedShort"/>
+					<xs:element name="PDMinCoilCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="PDMaxCoilCurrent" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="SDManufacturerSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                     -->
+	<!-- WPT Alignment Check -->
+	<!--                     -->
+	<xs:element name="WPT_AlignmentCheckReq" type="WPT_AlignmentCheckReqType"/>
+	<xs:complexType name="WPT_AlignmentCheckReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GRequestType">
+				<xs:sequence>
+					<xs:element name="EVProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="TargetCoilCurrent" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVResultCode" type="WPT_EVResultType"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="WPT_AlignmentCheckRes" type="WPT_AlignmentCheckResType"/>
+	<xs:complexType name="WPT_AlignmentCheckResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:V2GResponseType">
+				<xs:sequence>
+					<xs:element name="EVSEProcessing" type="v2gci_ct:processingType"/>
+					<xs:element name="PowerTransmitted" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="SupplyDeviceCurrent" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="VendorSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                 -->
+	<!-- WPT Charge Loop -->
+	<!--                 -->
+	<xs:element name="WPT_ChargeLoopReq" type="WPT_ChargeLoopReqType"/>
+	<xs:complexType name="WPT_ChargeLoopReqType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeLoopReqType">
+				<xs:sequence>
+					<xs:element name="EVPCPowerRequest" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVPCPowerOutput" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="EVPCChargeDiagnostics" type="WPT_EVPCChargeDiagnosticsType"/>
+					<xs:element name="EVPCOperatingFrequency" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="EVPCPowerControlParameter" type="WPT_EVPCPowerControlParameterType" minOccurs="0"/>
+					<xs:element name="ManufacturerSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="WPT_ChargeLoopRes" type="WPT_ChargeLoopResType"/>
+	<xs:complexType name="WPT_ChargeLoopResType">
+		<xs:complexContent>
+			<xs:extension base="v2gci_ct:ChargeLoopResType">
+				<xs:sequence>
+					<xs:element name="EVPCPowerRequest" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="SDPowerInput" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="SPCMaxOutputPowerLimit" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="SPCMinOutputPowerLimit" type="v2gci_ct:RationalNumberType"/>
+					<xs:element name="SPCChargeDiagnostics" type="WPT_SPCChargeDiagnosticsType"/>
+					<xs:element name="SPCOperatingFrequency" type="v2gci_ct:RationalNumberType" minOccurs="0"/>
+					<xs:element name="SPCPowerControlParameter" type="WPT_SPCPowerControlParameterType" minOccurs="0"/>
+					<xs:element name="ManufacturerSpecificDataContainer" type="WPT_DataContainerType" minOccurs="0" maxOccurs="16"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--                        -->
+	<!-- –––––––––––––––––––––– -->
+	<!-- Message Specific Types -->
+	<!-- –––––––––––––––––––––– -->
+	<xs:simpleType name="WPT_FinePositioningMethodType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Manual"/>
+			<xs:enumeration value="LF_TxEV"/>
+			<xs:enumeration value="LF_TxPrimaryDevice"/>
+			<xs:enumeration value="LPE"/>
+			<xs:enumeration value="Proprietary"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WPT_FinePositioningMethodListType">
+		<xs:sequence>
+			<xs:element name="WPT_FinePositioningMethod" type="WPT_FinePositioningMethodType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="WPT_PairingMethodType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="External confirmation"/>
+			<xs:enumeration value="LPE"/>
+			<xs:enumeration value="LF_TxEV"/>
+			<xs:enumeration value="LF_TxPrimaryDevice"/>
+			<xs:enumeration value="Optical"/>
+			<xs:enumeration value="Proprietary"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WPT_PairingMethodListType">
+		<xs:sequence>
+			<xs:element name="WPT_PairingMethod" type="WPT_PairingMethodType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="WPT_AlignmentCheckMethodType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="PowerCheck"/>
+			<xs:enumeration value="LPE"/>
+			<xs:enumeration value="Proprietary"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WPT_AlignmentCheckMethodListType">
+		<xs:sequence>
+			<xs:element name="WPT_AlignmentCheckMethod" type="WPT_AlignmentCheckMethodType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="WPT_EVPCChargeDiagnosticsType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EVPCNoIssue"/>
+			<xs:enumeration value="EVPCTempOverheatDetected"/>
+			<xs:enumeration value="EVPCPowerTransferAnomalyDetected"/>
+			<xs:enumeration value="EVPCAnomalyDetected"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WPT_SPCChargeDiagnosticsType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SPCNoIssue"/>
+			<xs:enumeration value="SPCFODDetected"/>
+			<xs:enumeration value="SPCLOPDetected"/>
+			<xs:enumeration value="SPCTempOverheatDetected"/>
+			<xs:enumeration value="SPCPowerTransferAnomalyDetected"/>
+			<xs:enumeration value="SPCAnomalyDetected"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WPT_PowerClassType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="MF-WPT1"/>
+			<xs:enumeration value="MF-WPT2"/>
+			<xs:enumeration value="MF-WPT3"/>
+			<xs:enumeration value="MF-WPT4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="WPT_EVResultType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EVResultUnknown"/>
+			<xs:enumeration value="EVResultSuccess"/>
+			<xs:enumeration value="EVResultFailed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="WPT_EVPCPowerControlParameterType">
+		<xs:sequence>
+			<xs:element name="EVPCCoilCurrentRequest" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVPCCoilCurrentInformation" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVPCCurrentOutputInformation" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="EVPCVoltageOutputInformation" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_SPCPowerControlParameterType">
+		<xs:sequence>
+			<xs:element name="SPCPrimaryDeviceCoilCurrentInformation" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_SystemSetupDataType">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="LF_TransmitterSetupData" type="WPT_LF_TransmitterDataType"/>
+				<xs:element name="LF_ReceiverSetupData" type="WPT_LF_ReceiverDataType"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_TransmitterDataType">
+		<xs:sequence>
+			<xs:element name="NumberOfTransmitters" type="xs:unsignedByte"/>
+			<xs:element name="SignalFrequency" type="v2gci_ct:RationalNumberType"/>
+			<xs:element name="TxSpecData" type="WPT_TxRxSpecDataType" minOccurs="2" maxOccurs="255"/>
+			<xs:element name="TxPackageSpecData" type="WPT_TxRxPackageSpecDataType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_ReceiverDataType">
+		<xs:sequence>
+			<xs:element name="NumberOfReceivers" type="xs:unsignedByte"/>
+			<xs:element name="RxSpecData" type="WPT_TxRxSpecDataType" minOccurs="2" maxOccurs="255"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_TxRxSpecDataType">
+		<xs:sequence>
+			<xs:element name="TxRxIdentifier" type="v2gci_ct:numericIDType"/>
+			<xs:element name="TxRxPosition" type="WPT_CoordinateXYZType"/>
+			<xs:element name="TxRxOrientation" type="WPT_CoordinateXYZType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_CoordinateXYZType">
+		<xs:sequence>
+			<xs:element name="Coord_X" type="xs:short"/>
+			<xs:element name="Coord_Y" type="xs:short"/>
+			<xs:element name="Coord_Z" type="xs:short"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_TxRxPackageSpecDataType">
+		<xs:sequence>
+			<xs:element name="PulseSequenceOrder" type="WPT_TxRxPulseOrderType" minOccurs="2" maxOccurs="255"/>
+			<xs:element name="PulseSeparationTime" type="xs:unsignedShort"/>
+			<xs:element name="PulseDuration" type="xs:unsignedShort"/>
+			<xs:element name="PackageSeparationTime" type="xs:unsignedShort"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_TxRxPulseOrderType">
+		<xs:sequence>
+			<xs:element name="IndexNumber" type="xs:unsignedShort"/>
+			<xs:element name="TxRxIdentifier" type="v2gci_ct:numericIDType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_TxDataListType">
+		<xs:sequence>
+			<xs:element name="WPT_LF_TxDataList" type="WPT_LF_TxDataType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_TxDataType">
+		<xs:sequence>
+			<xs:element name="TxIdentifier" type="v2gci_ct:numericIDType"/>
+			<xs:element name="EIRP" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_RxDataListType">
+		<xs:sequence>
+			<xs:element name="WPT_LF_RxDataList" type="WPT_LF_RxDataType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_RxDataType">
+		<xs:sequence>
+			<xs:element name="RxIdentifier" type="v2gci_ct:numericIDType"/>
+			<xs:element name="RSSIData" type="WPT_LF_RxRSSIListType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_RxRSSIListType">
+		<xs:sequence>
+			<xs:element name="RSSIDataList" type="WPT_LF_RxRSSIType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_RxRSSIType">
+		<xs:sequence>
+			<xs:element name="TxIdentifier" type="v2gci_ct:numericIDType"/>
+			<xs:element name="RSSI" type="v2gci_ct:RationalNumberType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_DataPackageListType">
+		<xs:sequence>
+			<xs:element name="NumPackages" type="xs:unsignedByte"/>
+			<xs:element name="WPT_LF_DataPackage" type="WPT_LF_DataPackageType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="WPT_LF_DataPackageType">
+		<xs:sequence>
+			<xs:element name="PackageIndex" type="xs:unsignedByte"/>
+			<xs:choice>
+				<xs:element name="LF_TxData" type="WPT_LF_TxDataListType"/>
+				<xs:element name="LF_RxData" type="WPT_LF_RxDataListType"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AlternativeSECCListType">
+		<xs:sequence>
+			<xs:element name="AlternativeSECC" type="AlternativeSECCType" maxOccurs="8"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--AlternativeSECCTYpe is connection information for an alternative SECC-->
+	<xs:complexType name="AlternativeSECCType">
+		<xs:sequence>
+			<xs:element name="SSID" type="v2gci_ct:identifierType" minOccurs="0"/>
+			<xs:element name="BSSID" type="bssidType" minOccurs="0"/>
+			<xs:element name="IPAddress" type="ipaddressType" minOccurs="0"/>
+			<xs:element name="Port" type="xs:unsignedShort" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--BSSIDType: hexa-decimal string representation of the MAC address of the AP in upper case-->
+	<xs:simpleType name="bssidType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="12"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--IPAddressType: hexa-decimal string representation of the IPv6 address of the SECC 
+	including colons, in upper case-->
+	<xs:simpleType name="ipaddressType">
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="39"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ––––––––––––––   -->
+	<!-- Simple WPT Types -->
+	<!-- ––––––––––––––   -->
+	<xs:simpleType name="WPT_DataContainerType">
+		<xs:restriction base="xs:base64Binary">
+			<xs:maxLength value="256"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/tools/schemas/iso20/xmldsig-core-schema.xsd
+++ b/tools/schemas/iso20/xmldsig-core-schema.xsd
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schema
+  PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
+ [
+   <!ATTLIST schema 
+     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        targetNamespace="http://www.w3.org/2000/09/xmldsig#"
+        version="0.1" elementFormDefault="qualified"> 
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence> 
+    <element ref="ds:SignedInfo"/> 
+    <element ref="ds:SignatureValue"/> 
+    <element ref="ds:KeyInfo" minOccurs="0"/> 
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/> 
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence> 
+    <element ref="ds:CanonicalizationMethod"/> 
+    <element ref="ds:SignatureMethod"/> 
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/> 
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence> 
+    <element ref="ds:Transforms" minOccurs="0"/> 
+    <element ref="ds:DigestMethod"/> 
+    <element ref="ds:DigestValue"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="URI" type="anyURI" use="optional"/> 
+  <attribute name="Type" type="anyURI" use="optional"/> 
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>  
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded"> 
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/> 
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true"> 
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>    
+  <attribute name="Algorithm" type="anyURI" use="required"/> 
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/> 
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">     
+    <element ref="ds:KeyName"/> 
+    <element ref="ds:KeyValue"/> 
+    <element ref="ds:RetrievalMethod"/> 
+    <element ref="ds:X509Data"/> 
+    <element ref="ds:PGPData"/> 
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/> 
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/> 
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/> 
+    </sequence>  
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/> 
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType"> 
+  <sequence> 
+    <element name="X509IssuerName" type="string"/> 
+    <element name="X509SerialNumber" type="integer"/> 
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/> 
+<complexType name="PGPDataType"> 
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/> 
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/> 
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType> 
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/> 
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/> 
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/> 
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/> 
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/> 
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/> 
+     <attribute name="Id" type="ID" use="optional"/> 
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/> 
+    <element name="Exponent" type="ds:CryptoBinary"/> 
+  </sequence>
+</complexType> 
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>


### PR DESCRIPTION
## Summary
- fetch ISO 15118-20 schemas from the official ISO site
- ignore local Python virtual environment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_686a24a7b10c8324a9db9594a4f4ea20